### PR TITLE
Support for Ubuntu 22.04 / Python 3.10

### DIFF
--- a/motmetrics/distances.py
+++ b/motmetrics/distances.py
@@ -76,7 +76,7 @@ def boxiou(a, b):
     a_vol = np.prod(a_size, axis=-1)
     b_vol = np.prod(b_size, axis=-1)
     u_vol = a_vol + b_vol - i_vol
-    return np.where(i_vol == 0, np.zeros_like(i_vol, dtype=np.float),
+    return np.where(i_vol == 0, np.zeros_like(i_vol, dtype=float),
                     math_util.quiet_divide(i_vol, u_vol))
 
 

--- a/motmetrics/mot.py
+++ b/motmetrics/mot.py
@@ -175,9 +175,9 @@ class MOTAccumulator(object):
 
         self.dirty_events = True
         oids = np.asarray(oids)
-        oids_masked = np.zeros_like(oids, dtype=np.bool)
+        oids_masked = np.zeros_like(oids, dtype=bool)
         hids = np.asarray(hids)
-        hids_masked = np.zeros_like(hids, dtype=np.bool)
+        hids_masked = np.zeros_like(hids, dtype=bool)
         dists = np.atleast_2d(dists).astype(float).reshape(oids.shape[0], hids.shape[0]).copy()
 
         if frameid is None:


### PR DESCRIPTION
Replace np.float -> float and np.bool -> bool  ;  to is required by newer Python, and is supported by older Python/numpy.